### PR TITLE
licsense declared in README.md, but LICENSE file missing in REPO

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 mrzepa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+


### PR DESCRIPTION
Cool Project! Thank you!
I would like to try bundle this project to nixos.org as package. (There is already a lot of other unifi infrastructure there.)

Problem:
- License declared in README.md as MIT, but linked file goes to 404 / file missing. (https://github.com/mrzepa/unifi2netbox/blob/main/LICENSE) -> fix: attached a one button click merge proposal 

Just in case you have a minute to spare ...  (info/optional)
- There is no release tag: could you consider to set an semver (https://en.wikipedia.org/wiki/Software_versioning) release tag?
- A dream would be having a maintainer/owner supported build support, example https://packaging.python.org/en/latest/guides/writing-pyproject-toml (or whatever your personal preference is)